### PR TITLE
Php71 etc

### DIFF
--- a/fpa-en.php
+++ b/fpa-en.php
@@ -1650,6 +1650,15 @@
 			$dBconn = @mysql_connect( $instance['configDBHOST'], $instance['configDBUSER'], $instance['configDBPASS'] );
 			$database['dbERROR'] = mysql_errno() .':'. mysql_error();
 
+    mysql_select_db( $instance['configDBNAME'], $dBconn );
+    $sql = "select name,type,enabled from ".$instance['configDBPREF']."extensions where type='plugin' or type='component' or type='module' or type='template'";
+    $result = mysql_query($sql);
+    if (mysql_num_rows($result) > 0) {
+      for ($exset = array ();
+      $row = mysql_fetch_array($result);
+      $exset[] = $row);
+     }
+
 			if ( $dBconn ) {
 				mysql_select_db( $instance['configDBNAME'], $dBconn );
 				$database['dbERROR'] = mysql_errno() .':'. mysql_error();
@@ -1736,6 +1745,14 @@
 	This will help maintain php 5 compatibility and possibly eliminate the user reported issue of "FPA never finishes" complaints
 	when running FPA on some systems. Phil 09-14-2012 **/
 
+
+    $sql = "select name,type,enabled from ". $instance['configDBPREF']."extensions where type='plugin' or type='component' or type='module' or type='template'";
+    $result = $dBconn->query($sql);
+    if ($result->num_rows > 0) {
+      for ($exset = array ();
+      $row = $result->fetch_assoc();
+      $exset[] = $row);
+     }
 			if ( $dBconn ) {
 				$database['dbHOSTSERV']     = @mysqli_get_server_info( $dBconn );       // SQL server version
 				$database['dbHOSTINFO']     = @mysqli_get_host_info( $dBconn );         // connection type to dB
@@ -1984,7 +2001,17 @@
 	} // end if instanceFOUND
 ?>
 
-
+<?php
+function recursive_array_search($needle,$haystack) {
+    foreach($haystack as $key=>$value) {
+        $current_key=$key;
+        if($needle===$value OR (is_array($value) && recursive_array_search($needle,$value) !== false)) {
+            return $current_key;
+        }
+    }
+    return false;
+}
+?>
 
 
 
@@ -3962,69 +3989,97 @@
 								echo '[color=#000000][b]'. _FPA_EXTCOM_TITLE .' :: '. _FPA_SITE .' :: [/b][/color]';
 
 									foreach ( $component['SITE'] as $key => $show ) {
+                    if (isset($exset[0]['name'])) { 
+                    $extarrkey = recursive_array_search($show['name'], $exset);
+                    $extenabled = $exset[$extarrkey]['enabled'];
+                     } else { $extenabled = '' ;}
+                     if ($extenabled <> 0 AND $extenabled <> 1 ){
+                     $extenabled = '';
+                   } else {
 										if ( $show['type'] == _FPA_3PD OR $showCoreEx == 1)
 										{                      
 										if ( $show['type'] == _FPA_3PD)
 										{                     
-										echo '[color=#ffa500]'. $show['name'] .' ('. $show['version'] .') [/color] [color=#000000][b] | [/b][/color]';
+										echo '[color=#ffa500]'. $show['name'] .' ('. $show['version'] .') [/color] [color=#000000][b] '.$extenabled.' | [/b][/color]';
 										} else {
-										echo '[color=#0000ff]'. $show['name'] .' ('. $show['version'] .') [/color] [color=#000000][b] | [/b][/color]';
+										echo '[color=#0000ff]'. $show['name'] .' ('. $show['version'] .') [/color] [color=#000000][b] '.$extenabled.' | [/b][/color]';
 										}
 									}
+  							}							
 							}
 								echo "\r\n";
 
 								echo '[color=#000000][b]'. _FPA_EXTCOM_TITLE .' :: '. _FPA_ADMIN .' :: [/b][/color]';
 
 									foreach ( $component['ADMIN'] as $key => $show ) {
+                    if (isset($exset[0]['name'])) {
+                    $extarrkey = recursive_array_search($show['name'], $exset);
+                    $extenabled = $exset[$extarrkey]['enabled'];
+                     } else { $extenabled = '' ;}
+                     if ($extenabled <> 0 AND $extenabled <> 1 ){
+                     $extenabled = '';
+                   } else {
 										if ( $show['type'] == _FPA_3PD OR $showCoreEx == 1)
 										{                      
 										if ( $show['type'] == _FPA_3PD)
 										{                     
-										echo '[color=#ffa500]'. $show['name'] .' ('. $show['version'] .') [/color] [color=#000000][b] | [/b][/color]';
+										echo '[color=#ffa500]'. $show['name'] .' ('. $show['version'] .') [/color] [color=#000000][b] '.$extenabled.' | [/b][/color]';
 										} else {
-										echo '[color=#0000ff]'. $show['name'] .' ('. $show['version'] .') [/color] [color=#000000][b] | [/b][/color]';
+										echo '[color=#0000ff]'. $show['name'] .' ('. $show['version'] .') [/color] [color=#000000][b] '.$extenabled.' | [/b][/color]';
 										}
 									}
-
-							}
-							}
+                } 
+  						}
+						}
 								echo "\r\n\r\n";
-//                        }
 
 
 							if ( @$_POST['showModules'] == '1' ) {
 								echo '[color=#000000][b]'. _FPA_EXTMOD_TITLE .' :: '. _FPA_SITE .' :: [/b][/color]';
 
 									foreach ( $module['SITE'] as $key => $show ) {
+                    if (isset($exset[0]['name'])) {
+                    $extarrkey = recursive_array_search($show['name'], $exset);
+                    $extenabled = $exset[$extarrkey]['enabled'];
+                     } else { $extenabled = '' ;}
+                     if ($extenabled <> 0 AND $extenabled <> 1 ){
+                     $extenabled = '';
+                   } else {
 										if ( $show['type'] == _FPA_3PD OR $showCoreEx == 1)
 										{                      
 										if ( $show['type'] == _FPA_3PD)
 										{                     
-										echo '[color=#ffa500]'. $show['name'] .' ('. $show['version'] .') [/color] [color=#000000][b] | [/b][/color]';
+										echo '[color=#ffa500]'. $show['name'] .' ('. $show['version'] .') [/color] [color=#000000][b] '.$extenabled.' | [/b][/color]';
 										} else {
-										echo '[color=#0000ff]'. $show['name'] .' ('. $show['version'] .') [/color] [color=#000000][b] | [/b][/color]';
+										echo '[color=#0000ff]'. $show['name'] .' ('. $show['version'] .') [/color] [color=#000000][b] '.$extenabled.' | [/b][/color]';
 										}
 									}
-
+  							}
 							}
 								echo "\r\n";
 
 								echo '[color=#000000][b]'. _FPA_EXTMOD_TITLE .' :: '. _FPA_ADMIN .' :: [/b][/color]';
 
 									foreach ( $module['ADMIN'] as $key => $show ) {
+                    if (isset($exset[0]['name'])) {
+                    $extarrkey = recursive_array_search($show['name'], $exset);
+                    $extenabled = $exset[$extarrkey]['enabled'];
+                     } else { $extenabled = '' ;}
+                     if ($extenabled <> 0 AND $extenabled <> 1 ){
+                     $extenabled = '';
+                   } else {
 										if ( $show['type'] == _FPA_3PD OR $showCoreEx == 1)
 										{                      
 										if ( $show['type'] == _FPA_3PD)
 										{                     
-										echo '[color=#ffa500]'. $show['name'] .' ('. $show['version'] .') [/color] [color=#000000][b] | [/b][/color]';
+										echo '[color=#ffa500]'. $show['name'] .' ('. $show['version'] .') [/color] [color=#000000][b] '.$extenabled.' | [/b][/color]';
 										} else {
-										echo '[color=#0000ff]'. $show['name'] .' ('. $show['version'] .') [/color] [color=#000000][b] | [/b][/color]';
+										echo '[color=#0000ff]'. $show['name'] .' ('. $show['version'] .') [/color] [color=#000000][b] '.$extenabled.' | [/b][/color]';
 										}
 									}
-
+  							}                
 							}
-							}
+						}
 							echo "\r\n\r\n";
 
 
@@ -4033,17 +4088,23 @@
 								echo '[color=#000000][b]'. _FPA_EXTPLG_TITLE .' :: '. _FPA_SITE .' :: [/b][/color]';
 
 									foreach ( $plugin['SITE'] as $key => $show ) {
+                    if (isset($exset[0]['name'])) { 
+                    $extarrkey = recursive_array_search($show['name'], $exset);
+                    $extenabled = $exset[$extarrkey]['enabled'];
+                     } else { $extenabled = '' ;}
+                     if ($extenabled <> 0 AND $extenabled <> 1 ){
+                     $extenabled = '';
+                   } else {
 										if ( $show['type'] == _FPA_3PD OR $showCoreEx == 1)
 										{                      
 										if ( $show['type'] == _FPA_3PD)
 										{                     
-										echo '[color=#ffa500]'. $show['name'] .' ('. $show['version'] .') [/color] [color=#000000][b] | [/b][/color]';
+										echo '[color=#ffa500]'. $show['name'] .' ('. $show['version'] .') [/color] [color=#000000][b] '.$extenabled.' | [/b][/color]';
 										} else {
-										echo '[color=#0000ff]'. $show['name'] .' ('. $show['version'] .') [/color] [color=#000000][b] | [/b][/color]';
+										echo '[color=#0000ff]'. $show['name'] .' ('. $show['version'] .') [/color] [color=#000000][b] '.$extenabled.' | [/b][/color]';
 										}
 									}
-
-							}
+			   				}
 							}
 							echo '[/size][/quote]';
 
@@ -4064,37 +4125,51 @@
 									echo '[color=#000000][b]'. _FPA_TMPL_TITLE .' :: '. _FPA_SITE .' :: [/b][/color]';
 
 										foreach ( $template['SITE'] as $key => $show ) {
-                      if ( $show['type'] == _FPA_3PD OR $showCoreEx == 1)
-                      {                      
-                      if ( $show['type'] == _FPA_3PD)
-                      {                     
-                      echo '[color=#ffa500]'. $show['name'] .' ('. $show['version'] .') [/color] [color=#000000][b] | [/b][/color]';
-                      } else {
-                      echo '[color=#0000ff]'. $show['name'] .' ('. $show['version'] .') [/color] [color=#000000][b] | [/b][/color]';
-                      }
-									}
-									}
-
+                    if (isset($exset[0]['name'])) { 
+                    $extarrkey = recursive_array_search($show['name'], $exset);
+                    $extenabled = $exset[$extarrkey]['enabled'];
+                     } else { $extenabled = '' ;}
+                     if ($extenabled <> 0 AND $extenabled <> 1 ){
+                     $extenabled = '';
+                    } else {
+										if ( $show['type'] == _FPA_3PD OR $showCoreEx == 1)
+										{                      
+										if ( $show['type'] == _FPA_3PD)
+										{                     
+										echo '[color=#ffa500]'. $show['name'] .' ('. $show['version'] .') [/color] [color=#000000][b] '.$extenabled.' | [/b][/color]';
+										} else {
+										echo '[color=#0000ff]'. $show['name'] .' ('. $show['version'] .') [/color] [color=#000000][b] '.$extenabled.' | [/b][/color]';
+                    }
+				  				}
+								}
+				 			}
 									echo "\r\n";
 
 									echo '[color=#000000][b]'. _FPA_TMPL_TITLE .' :: '. _FPA_ADMIN .' :: [/b][/color]';
 
 										foreach ( $template['ADMIN'] as $key => $show ) {
-                      if ( $show['type'] == _FPA_3PD OR $showCoreEx == 1)
-                      {                      
-                      if ( $show['type'] == _FPA_3PD)
-                      {                     
-                      echo '[color=#ffa500]'. $show['name'] .' ('. $show['version'] .') [/color] [color=#000000][b] | [/b][/color]';
-                      } else {
-                      echo '[color=#0000ff]'. $show['name'] .' ('. $show['version'] .') [/color] [color=#000000][b] | [/b][/color]';
-                      }
+                    if (isset($exset[0]['name'])) {
+                    $extarrkey = recursive_array_search($show['name'], $exset);
+                    $extenabled = $exset[$extarrkey]['enabled'];
+                     } else { $extenabled = '' ;}
+                     if ($extenabled <> 0 AND $extenabled <> 1 ){
+                     $extenabled = '';
+                    } else {
+										if ( $show['type'] == _FPA_3PD OR $showCoreEx == 1)
+										{                      
+										if ( $show['type'] == _FPA_3PD)
+										{                     
+										echo '[color=#ffa500]'. $show['name'] .' ('. $show['version'] .') [/color] [color=#000000][b] '.$extenabled.' | [/b][/color]';
+										} else {
+										echo '[color=#0000ff]'. $show['name'] .' ('. $show['version'] .') [/color] [color=#000000][b] '.$extenabled.' | [/b][/color]';
+                    }
 									}
-
+					   		}
 							}
-							}
+						}
 									echo '[/size][/quote]';
-
-								} // end if InstanceFOUND
+					}
+					} // end if InstanceFOUND
 
 						} // end showProtected != strict
 

--- a/fpa-en.php
+++ b/fpa-en.php
@@ -7,8 +7,8 @@
 
 /**
  **  @package Forum Post Assistant / Bug Report Assistant
- **  @version 1.2.7
- **  @last updated 04/12/2016
+ **  @version 1.2.8
+ **  @last updated 11/02/2017
  **  @release Beta
  **  @date 24/06/2011
  **  @author RussW
@@ -50,8 +50,8 @@
 		define ( '_RES', 'Forum Post Assistant' );
 	}
 
-	define ( '_RES_VERSION', '1.2.7' );
-	define ( '_last_updated', '04/12/2016' );
+	define ( '_RES_VERSION', '1.2.8' );
+	define ( '_last_updated', '11/02/2017' );
 	define ( '_COPYRIGHT_STMT', ' Copyright (C) 2011, 2012 Russell Winter, Phil DeGruy, Bernard Toplak &nbsp;' );
 	define ( '_LICENSE_LINK', '<a href="http://www.gnu.org/licenses/" target="_blank">http://www.gnu.org/licenses/</a>' ); // link to GPL license
 	define ( '_LICENSE_FOOTER', ' The FPA comes with ABSOLUTELY NO WARRANTY. &nbsp; This is free software,
@@ -763,6 +763,10 @@
 	} elseif ( file_exists( 'libraries/cms/version/version.php' ) AND file_exists( 'libraries/platform.php' ) ) {
 		$instance['cmsVFILE'] = 'libraries/cms/version/version.php';
 
+	// >= J3.6.3
+	} elseif ( file_exists( 'libraries/cms/version/version.php' ) AND !file_exists( 'libraries/platform.php' ) ) {
+		$instance['cmsVFILE'] = 'libraries/cms/version/version.php';    
+    
 	// fpa could find the required files to determine version(s)
 	} else {
 		$instance['cmsVFILE'] = _FPA_N;
@@ -945,6 +949,11 @@
 			if ( preg_match ( '#(\$mosConfig_)#', $cmsCContent ) ) {
 				$instance['configVALIDFOR'] = '1.0';
 				$instance['instanceCFGVERMATCH'] = _FPA_Y;
+  	// >= 3.6.3
+			} elseif ( preg_match ( '#(public)#', $cmsCContent ) AND $instance['platformVFILE'] == _FPA_N AND file_exists( 'libraries/cms/version/version.php' ) ) {
+				$instance['configVALIDFOR'] = $instance['cmsRELEASE'];
+				$instance['cmsVFILE'] = 'libraries/cms/version/version.php';
+				$instance['instanceCFGVERMATCH'] = _FPA_Y;
 		// for 1.5
 			} elseif ( preg_match ( '#(var)#', $cmsCContent ) ) {
 				$instance['configVALIDFOR'] = '1.5';
@@ -1112,7 +1121,7 @@
 			}
 
 			// check if all the DB credentials are complete
-			if ( @$instance['configDBTYPE'] AND $instance['configDBHOST'] AND $instance['configDBNAME'] AND $instance['configDBPREF'] AND $instance['configDBUSER'] AND $instance['configDBPASS'] ) {
+			if ( @$instance['configDBTYPE'] AND $instance['configDBHOST'] AND $instance['configDBNAME'] AND $instance['configDBPREF'] AND $instance['configDBUSER'] ) {
 				$instance['configDBCREDOK'] = _FPA_Y;
 
 			} else {
@@ -1874,7 +1883,7 @@
 								$content = file_get_contents( $cDir );
 
 								if ( preg_match( '#<(extension|install|mosinstall)#', $content, $isValidFile ) ) {
-									$arrname[$loc][$cDir] = '';
+									unset($arrname[$loc][$cDir]);
 
 									$arrname[$loc][$cDir]['author']         = '-';
 									$arrname[$loc][$cDir]['authorUrl']      = '-';
@@ -1902,6 +1911,8 @@
 									OR strtolower( $name[1] ) == 'bluestork'
 									OR strtolower( $name[1] ) == 'atomic'
 									OR strtolower( $name[1] ) == 'hathor'
+									OR strtolower( $name[1] ) == 'protostar'
+									OR strtolower( $name[1] ) == 'isis'
 									OR strtolower( $name[1] ) == 'beez5'
 									OR strtolower( $name[1] ) == 'beez_20'
 									OR strtolower( substr( $name[1], 0, 4 ) ) == 'beez' ) {
@@ -2352,7 +2363,7 @@
 	** BAD SQL  | -----  | -----  |        >5.0.0          |  -----  |
 	** BAD ZEND | -----  | -----  |         2.5.10         |  -----  |
 	*****************************************************************************************/
-	$fpa['supportENV'] = '';
+  unset($fpa['supportENV']);
 
 	echo '<div>';
 	echo '<div style="width:85%;margin:0 auto;margin-top:10px;">';
@@ -2378,7 +2389,35 @@
 		Mysql:
 		On Medialayer at least, mysql 5.0.87-community will work with current versions of Joomla and has inno db enabled
 		*******/
-		if ( @$instance['cmsRELEASE'] == '3.2' and @$instance['cmsDEVLEVEL'] >= 1) {
+    if ( @$instance['cmsRELEASE'] >= '3.5')  {
+		$fpa['supportENV']['minPHP']        = '5.3.10';
+		$fpa['supportENV']['minSQL']        = '5.1.0';
+		$fpa['supportENV']['maxPHP']        = '7.1.1';  
+		$fpa['supportENV']['maxSQL']        = '5.7.14'; 
+		$fpa['supportENV']['badPHP'][0]     = '5.3.0';
+		$fpa['supportENV']['badPHP'][1]     = '5.3.1';
+		$fpa['supportENV']['badPHP'][2]     = '5.3.2';
+		$fpa['supportENV']['badPHP'][3]     = '5.3.3';
+		$fpa['supportENV']['badPHP'][4]     = '5.3.4';
+		$fpa['supportENV']['badPHP'][5]     = '5.3.5';
+		$fpa['supportENV']['badPHP'][6]     = '5.3.6';
+		$fpa['supportENV']['badZND'][0]     = _FPA_NA;
+
+	} elseif ( @$instance['cmsRELEASE']  == '3.3' or @$instance['cmsRELEASE']  == '3.4')  {
+		$fpa['supportENV']['minPHP']        = '5.3.10';
+		$fpa['supportENV']['minSQL']        = '5.1.0';
+		$fpa['supportENV']['maxPHP']        = '5.6.30';  
+		$fpa['supportENV']['maxSQL']        = '5.7.14'; 
+		$fpa['supportENV']['badPHP'][0]     = '5.3.0';
+		$fpa['supportENV']['badPHP'][1]     = '5.3.1';
+		$fpa['supportENV']['badPHP'][2]     = '5.3.2';
+		$fpa['supportENV']['badPHP'][3]     = '5.3.3';
+		$fpa['supportENV']['badPHP'][4]     = '5.3.4';
+		$fpa['supportENV']['badPHP'][5]     = '5.3.5';
+		$fpa['supportENV']['badPHP'][6]     = '5.3.6';
+		$fpa['supportENV']['badZND'][0]     = _FPA_NA;
+
+	} elseif ( @$instance['cmsRELEASE'] == '3.2' and @$instance['cmsDEVLEVEL'] >= 1) {
 		$fpa['supportENV']['minPHP']        = '5.3.1';
 		$fpa['supportENV']['minSQL']        = '5.1.0';
 		$fpa['supportENV']['maxPHP']        = '6.0.0';  // latest release?
@@ -2749,6 +2788,9 @@
 	echo '<div style="clear:both;"></div>';
 	echo "<p></p>";
 	echo '<div style="text-align:center!important;"><a style="color:#4D8000!important;" href="'. _RES_FPALINK2 .''. _RES_LANG .'" target="_github">'. _RES_FPALATEST2 .' '. _RES .'</a><p></div>';
+	echo _FPA_DELNOTE_LN1;
+	echo _FPA_DELNOTE_LN2;
+	echo _FPA_DELNOTE_LN3;
 	echo '</div>';
 	showDev ( $snapshot );
 	?>

--- a/fpa-en.php
+++ b/fpa-en.php
@@ -150,6 +150,7 @@
 	define ( '_FPA_SHOWCOM', 'Show Components' );
 	define ( '_FPA_SHOWMOD', 'Show Modules' );
 	define ( '_FPA_SHOWPLG', 'Show Plugins' );
+	define ( '_FPA_SHOWCEX', 'Show Core Extentions' );
 	define ( '_FPA_INFOPRI', 'Information Privacy' );
 	define ( '_FPA_PRIVNON', 'None' );
 	define ( '_FPA_PRIVNONNOTE', 'No elements are masked' );
@@ -366,15 +367,15 @@
 
 	}
 
-	if ( @$_POST['showElevated'] == 1 ) {
-		$showElevated  = 1;
+	if ( @$_POST['showElevated'] == 0 AND  @$_POST['doIT'] == 1   ) {
+		$showElevated  = 0;
 
 	} else {
 		$showElevated = 1; // default 1(show) changed default to 1 Phil 4-20-12
 
 	}
 
-	if ( @$_POST['showTables'] == 1 ) {
+	if ( @$_POST['showTables'] == 1 AND  @$_POST['doIT'] == 1   ) {
 		$showTables  = 1;
 
 	} else {
@@ -382,28 +383,34 @@
 
 	}
 
-	if ( @$_POST['showComponents'] == 1 ) {
-		$showComponents  = 1;
+	if ( @$_POST['showComponents'] == 0 AND  @$_POST['doIT'] == 1   ) {
+		$showComponents  = 0;
 
 	} else {
 		$showComponents = 1; // default 0 (hide) changed default to 1 Phil 4-20-12
 
 	}
 
-	if ( @$_POST['showModules'] == 1 ) {
-		$showModules  = 1;
+	if ( @$_POST['showModules'] == 0 AND  @$_POST['doIT'] == 1   ) {
+		$showModules  = 0;
 
 	} else {
 		$showModules = 1; // default 0 (hide) changed default to 1 Phil 4-20-12
 
 	}
 
-	if ( @$_POST['showPlugins'] == 1 ) {
-		$showPlugins  = 1;
+	if ( @$_POST['showPlugins'] == 0 AND  @$_POST['doIT'] == 1  ) {
+		$showPlugins  = 0;
 
 	} else {
 		$showPlugins = 1; // default 0(hide) changed default to 1 Phil 4-20-12
 
+	}
+
+	if ( @$_POST['showCoreEx'] == 0 AND  @$_POST['doIT'] == 1 ) {
+		$showCoreEx  = 0;
+	} else {
+		$showCoreEx = 1; 
 	}
 
 	// setup the Post type (Forum=BBCode, GitHUB=markdown or JoomlaCode=plain-text)
@@ -2917,36 +2924,40 @@
 							<div style="float:left; width:170px;">
 
 							<?php
-								if ( @$_POST['showElevated'] ) {
-									$selectshowElevated = 'CHECKED';
+								if ( @$_POST['showElevated'] == 0 AND  @$_POST['doIT'] == 1  ) {
+									$selectshowElevated = '';
 								} else {
 									$selectshowElevated = 'CHECKED'; // changed to checked - Phil - 4-20-12
 								}
 
-								if ( @$_POST['showTables'] ) {
+								if ( @$_POST['showTables'] == 1 AND  @$_POST['doIT'] == 1  ) {
 									$selectshowTables = 'CHECKED';
 								} else {
 									$selectshowTables = '';
 								}
 
-								if ( @$_POST['showComponents'] ) {
-									$selectshowComponents = 'CHECKED';
+								if ( @$_POST['showComponents'] == 0 AND  @$_POST['doIT'] == 1  ) {
+									$selectshowComponents = '';
 								} else {
 									$selectshowComponents = 'CHECKED'; // changed to checked - Phil - 4-20-12
 								}
 
-								if ( @$_POST['showModules'] ) {
-									$selectshowModules = 'CHECKED';
+								if ( @$_POST['showModules'] == 0 AND  @$_POST['doIT'] == 1  ) {
+									$selectshowModules = '';
 								} else {
 									$selectshowModules = 'CHECKED'; // changed to checked - Phil - 4-20-12
 								}
 
-								if ( @$_POST['showPlugins'] ) {
-									$selectshowPlugins = 'CHECKED';
+								if ( @$_POST['showPlugins'] == 0 AND  @$_POST['doIT'] == 1  ) {
+									$selectshowPlugins = '';
 								} else {
 									$selectshowPlugins = 'CHECKED'; // changed to checked - Phil - 4-20-12
 								}
-
+								if ( @$_POST['showCoreEx'] == 0 AND  @$_POST['doIT'] == 1 ) {
+									$selectshowCoreEx = '';
+								} else {
+									$selectshowCoreEx = 'CHECKED';
+								}                
 								if ( $instance['instanceFOUND'] != _FPA_Y ) {
 									$dis = 'DISABLED';
 
@@ -2967,6 +2978,7 @@
 								<input <?php echo $dis; ?> style="font-size:9px;" type="checkbox" name="showComponents" value="1" <?php echo $selectshowComponents ?> /><span class="normal"><?php echo _FPA_SHOWCOM; ?></span><br />
 								<input <?php echo $dis; ?> style="font-size:9px;" type="checkbox" name="showModules" value="1" <?php echo $selectshowModules ?> /><span class="normal"><?php echo _FPA_SHOWMOD; ?></span><br />
 								<input <?php echo $dis; ?> style="font-size:9px;" type="checkbox" name="showPlugins" value="1" <?php echo $selectshowPlugins ?> /><span class="normal"><?php echo _FPA_SHOWPLG; ?></span><br />
+								<input <?php echo $dis; ?> style="font-size:9px;" type="checkbox" name="showCoreEx" value="1" <?php echo $selectshowCoreEx ?> /><span class="normal"><?php echo _FPA_SHOWCEX; ?></span><br />
 							</div>
 
 							<div style="float:right; width:150px;">
@@ -3222,10 +3234,10 @@
 
 									foreach ( $plugin['SITE'] as $key => $show ) {
 
-										if ( $show != @$plugin['ARRNAME'] ) {
+										if ( $show != @$plugin['ARRNAME'] ) 
+										{
 											echo $show['name'] .' ('. $show['version'] .') | ';
-										} // endif !arrname
-
+										} // endif !arrname  
 									}
 								} // end plugins
 
@@ -3950,19 +3962,34 @@
 								echo '[color=#000000][b]'. _FPA_EXTCOM_TITLE .' :: '. _FPA_SITE .' :: [/b][/color]';
 
 									foreach ( $component['SITE'] as $key => $show ) {
-										echo $show['name'] .' ('. $show['version'] .') | ';
+										if ( $show['type'] == _FPA_3PD OR $showCoreEx == 1)
+										{                      
+										if ( $show['type'] == _FPA_3PD)
+										{                     
+										echo '[color=#ffa500]'. $show['name'] .' ('. $show['version'] .') [/color] [color=#000000][b] | [/b][/color]';
+										} else {
+										echo '[color=#0000ff]'. $show['name'] .' ('. $show['version'] .') [/color] [color=#000000][b] | [/b][/color]';
+										}
 									}
-
+							}
 								echo "\r\n";
 
 								echo '[color=#000000][b]'. _FPA_EXTCOM_TITLE .' :: '. _FPA_ADMIN .' :: [/b][/color]';
 
 									foreach ( $component['ADMIN'] as $key => $show ) {
-										echo $show['name'] .' ('. $show['version'] .') | ';
+										if ( $show['type'] == _FPA_3PD OR $showCoreEx == 1)
+										{                      
+										if ( $show['type'] == _FPA_3PD)
+										{                     
+										echo '[color=#ffa500]'. $show['name'] .' ('. $show['version'] .') [/color] [color=#000000][b] | [/b][/color]';
+										} else {
+										echo '[color=#0000ff]'. $show['name'] .' ('. $show['version'] .') [/color] [color=#000000][b] | [/b][/color]';
+										}
 									}
 
-								echo "\r\n\r\n";
 							}
+							}
+								echo "\r\n\r\n";
 //                        }
 
 
@@ -3970,30 +3997,54 @@
 								echo '[color=#000000][b]'. _FPA_EXTMOD_TITLE .' :: '. _FPA_SITE .' :: [/b][/color]';
 
 									foreach ( $module['SITE'] as $key => $show ) {
-										echo $show['name'] .' ('. $show['version'] .') | ';
+										if ( $show['type'] == _FPA_3PD OR $showCoreEx == 1)
+										{                      
+										if ( $show['type'] == _FPA_3PD)
+										{                     
+										echo '[color=#ffa500]'. $show['name'] .' ('. $show['version'] .') [/color] [color=#000000][b] | [/b][/color]';
+										} else {
+										echo '[color=#0000ff]'. $show['name'] .' ('. $show['version'] .') [/color] [color=#000000][b] | [/b][/color]';
+										}
 									}
 
+							}
 								echo "\r\n";
 
 								echo '[color=#000000][b]'. _FPA_EXTMOD_TITLE .' :: '. _FPA_ADMIN .' :: [/b][/color]';
 
 									foreach ( $module['ADMIN'] as $key => $show ) {
-										echo $show['name'] .' ('. $show['version'] .') | ';
+										if ( $show['type'] == _FPA_3PD OR $showCoreEx == 1)
+										{                      
+										if ( $show['type'] == _FPA_3PD)
+										{                     
+										echo '[color=#ffa500]'. $show['name'] .' ('. $show['version'] .') [/color] [color=#000000][b] | [/b][/color]';
+										} else {
+										echo '[color=#0000ff]'. $show['name'] .' ('. $show['version'] .') [/color] [color=#000000][b] | [/b][/color]';
+										}
 									}
 
-							echo "\r\n\r\n";
 							}
+							}
+							echo "\r\n\r\n";
+
 
 
 							if ( @$_POST['showPlugins'] == '1' ) {
 								echo '[color=#000000][b]'. _FPA_EXTPLG_TITLE .' :: '. _FPA_SITE .' :: [/b][/color]';
 
 									foreach ( $plugin['SITE'] as $key => $show ) {
-										echo $show['name'] .' ('. $show['version'] .') | ';
+										if ( $show['type'] == _FPA_3PD OR $showCoreEx == 1)
+										{                      
+										if ( $show['type'] == _FPA_3PD)
+										{                     
+										echo '[color=#ffa500]'. $show['name'] .' ('. $show['version'] .') [/color] [color=#000000][b] | [/b][/color]';
+										} else {
+										echo '[color=#0000ff]'. $show['name'] .' ('. $show['version'] .') [/color] [color=#000000][b] | [/b][/color]';
+										}
 									}
 
 							}
-
+							}
 							echo '[/size][/quote]';
 
 						} // end if showComponents, Modules, Plugins, if cmsFOUND
@@ -4013,17 +4064,34 @@
 									echo '[color=#000000][b]'. _FPA_TMPL_TITLE .' :: '. _FPA_SITE .' :: [/b][/color]';
 
 										foreach ( $template['SITE'] as $key => $show ) {
-											echo $show['name'] .' ('. $show['version'] .') | ';
-										}
+                      if ( $show['type'] == _FPA_3PD OR $showCoreEx == 1)
+                      {                      
+                      if ( $show['type'] == _FPA_3PD)
+                      {                     
+                      echo '[color=#ffa500]'. $show['name'] .' ('. $show['version'] .') [/color] [color=#000000][b] | [/b][/color]';
+                      } else {
+                      echo '[color=#0000ff]'. $show['name'] .' ('. $show['version'] .') [/color] [color=#000000][b] | [/b][/color]';
+                      }
+									}
+									}
 
 									echo "\r\n";
 
 									echo '[color=#000000][b]'. _FPA_TMPL_TITLE .' :: '. _FPA_ADMIN .' :: [/b][/color]';
 
 										foreach ( $template['ADMIN'] as $key => $show ) {
-											echo $show['name'] .' ('. $show['version'] .') | ';
-										}
+                      if ( $show['type'] == _FPA_3PD OR $showCoreEx == 1)
+                      {                      
+                      if ( $show['type'] == _FPA_3PD)
+                      {                     
+                      echo '[color=#ffa500]'. $show['name'] .' ('. $show['version'] .') [/color] [color=#000000][b] | [/b][/color]';
+                      } else {
+                      echo '[color=#0000ff]'. $show['name'] .' ('. $show['version'] .') [/color] [color=#000000][b] | [/b][/color]';
+                      }
+									}
 
+							}
+							}
 									echo '[/size][/quote]';
 
 								} // end if InstanceFOUND
@@ -4048,7 +4116,6 @@
 				echo '<span class="ok">'. _FPA_INS_7 .'</span>'; // changed to _FPA_INS_7 from _FPA_INS_6  Phil - 4-21-12
 				echo '<div style="clear:both;"><br /></div>';
 				echo '</div>';
-			}
 		?>
 
 						</form>
@@ -5717,7 +5784,7 @@
 		// and make it easier to see what are 3rd party. The old code is marked out below.
 			foreach ( $component['SITE'] as $key => $show ) {
 
-				if ( $show['type'] == _FPA_3PD AND $showProtected <= 2) {
+				if ( $show['type'] == _FPA_3PD OR $showCoreEx == 1 AND $showProtected <= 2) {
 					$typeColor = '404040';
 					echo '<div><div style="float:left;width:20%;color:#'. $typeColor .';">'. $show['name'] .'</div><div style="float:left;width:15%;text-align:center;color:#'. $typeColor .';">'. $show['version'] .'</div><div style="float:left;width:15%;color:#'. $typeColor .';">'. $show['creationDate'] .'</div><div style="float:left;width:18%;color:#'. $typeColor .';">'. $show['author'] .'</div><div style="float:left;width:20%;color:#'. $typeColor .';">'. $show['authorUrl'] .'</div><div style="float:right;width:10%;color:#'. $typeColor .';text-align:center;">'. $show['type'] .'</div><br style="clear:both" /></div>';
 
@@ -5773,7 +5840,7 @@
 		// and make it easier to see what are 3rd party. The old code is marked out below.
 			foreach ( $component['ADMIN'] as $key => $show ) {
 
-				if ( $show['type'] == _FPA_3PD AND $showProtected <= 2) {
+				if ( $show['type'] == _FPA_3PD OR $showCoreEx == 1 AND $showProtected <= 2) {
 					$typeColor = '404040';
 					echo '<div><div style="float:left;width:20%;color:#'. $typeColor .';">'. $show['name'] .'</div><div style="float:left;width:15%;text-align:center;color:#'. $typeColor .';">'. $show['version'] .'</div><div style="float:left;width:15%;color:#'. $typeColor .';">'. $show['creationDate'] .'</div><div style="float:left;width:18%;color:#'. $typeColor .';">'. $show['author'] .'</div><div style="float:left;width:20%;color:#'. $typeColor .';">'. $show['authorUrl'] .'</div><div style="float:right;width:10%;color:#'. $typeColor .';text-align:center;">'. $show['type'] .'</div><br style="clear:both" /></div>';
 
@@ -5857,7 +5924,7 @@
 		// and make it easier to see what are 3rd party. The old code is marked out below.
 			foreach ( $module['SITE'] as $key => $show ) {
 
-				if ( $show['type'] == _FPA_3PD AND $showProtected <= 2) {
+				if ( $show['type'] == _FPA_3PD OR $showCoreEx == 1 AND $showProtected <= 2) {
 					$typeColor = '404040';
 					echo '<div><div style="float:left;width:20%;color:#'. $typeColor .';">'. $show['name'] .'</div><div style="float:left;width:15%;text-align:center;color:#'. $typeColor .';">'. $show['version'] .'</div><div style="float:left;width:15%;color:#'. $typeColor .';">'. $show['creationDate'] .'</div><div style="float:left;width:18%;color:#'. $typeColor .';">'. $show['author'] .'</div><div style="float:left;width:20%;color:#'. $typeColor .';">'. $show['authorUrl'] .'</div><div style="float:right;width:10%;color:#'. $typeColor .';text-align:center;">'. $show['type'] .'</div><br style="clear:both" /></div>';
 
@@ -5915,7 +5982,7 @@
 		// and make it easier to see what are 3rd party. The old code is marked out below.
 			foreach ( $module['ADMIN'] as $key => $show ) {
 
-				if ( $show['type'] == _FPA_3PD AND $showProtected <= 2) {
+				if ( $show['type'] == _FPA_3PD OR $showCoreEx == 1 AND $showProtected <= 2) {
 					$typeColor = '404040';
 					echo '<div><div style="float:left;width:20%;color:#'. $typeColor .';">'. $show['name'] .'</div><div style="float:left;width:15%;text-align:center;color:#'. $typeColor .';">'. $show['version'] .'</div><div style="float:left;width:15%;color:#'. $typeColor .';">'. $show['creationDate'] .'</div><div style="float:left;width:18%;color:#'. $typeColor .';">'. $show['author'] .'</div><div style="float:left;width:20%;color:#'. $typeColor .';">'. $show['authorUrl'] .'</div><div style="float:right;width:10%;color:#'. $typeColor .';text-align:center;">'. $show['type'] .'</div><br style="clear:both" /></div>';
 
@@ -6001,7 +6068,7 @@
 		// and make it easier to see what are 3rd party. The old code is marked out below.
 			foreach ( $plugin['SITE'] as $key => $show ) {
 
-				if ( $show['type'] == _FPA_3PD AND $showProtected <= 2) {
+				if ( $show['type'] == _FPA_3PD OR $showCoreEx == 1 AND $showProtected <= 2) {
 					$typeColor = '404040';
 					echo '<div><div style="float:left;width:20%;color:#'. $typeColor .';">'. $show['name'] .'</div><div style="float:left;width:15%;text-align:center;color:#'. $typeColor .';">'. $show['version'] .'</div><div style="float:left;width:15%;color:#'. $typeColor .';">'. $show['creationDate'] .'</div><div style="float:left;width:18%;color:#'. $typeColor .';">'. $show['author'] .'</div><div style="float:left;width:20%;color:#'. $typeColor .';">'. $show['authorUrl'] .'</div><div style="float:right;width:10%;color:#'. $typeColor .';text-align:center;">'. $show['type'] .'</div><br style="clear:both" /></div>';
 
@@ -6083,7 +6150,7 @@
 		// and make it easier to see what are 3rd party. The old code is marked out below.
 			foreach ( $template['SITE'] as $key => $show ) {
 
-				if ( $show['type'] == _FPA_3PD AND $showProtected <= 2) {
+				if ( $show['type'] == _FPA_3PD OR $showCoreEx == 1 AND $showProtected <= 2) {
 					$typeColor = '404040';
 					echo '<div><div style="float:left;width:20%;color:#'. $typeColor .';">'. $show['name'] .'</div><div style="float:left;width:15%;text-align:center;color:#'. $typeColor .';">'. $show['version'] .'</div><div style="float:left;width:15%;color:#'. $typeColor .';">'. $show['creationDate'] .'</div><div style="float:left;width:18%;color:#'. $typeColor .';">'. $show['author'] .'</div><div style="float:left;width:20%;color:#'. $typeColor .';">'. $show['authorUrl'] .'</div><div style="float:right;width:10%;color:#'. $typeColor .';text-align:center;">'. $show['type'] .'</div><br style="clear:both" /></div>';
 
@@ -6141,7 +6208,7 @@
 		// and make it easier to see what are 3rd party. The old code is marked out below.
 			foreach ( $template['ADMIN'] as $key => $show ) {
 
-				if ( $show['type'] == _FPA_3PD AND $showProtected <= 2) {
+				if ( $show['type'] == _FPA_3PD OR $showCoreEx == 1 AND $showProtected <= 2) {
 					$typeColor = '404040';
 					echo '<div><div style="float:left;width:20%;color:#'. $typeColor .';">'. $show['name'] .'</div><div style="float:left;width:15%;text-align:center;color:#'. $typeColor .';">'. $show['version'] .'</div><div style="float:left;width:15%;color:#'. $typeColor .';">'. $show['creationDate'] .'</div><div style="float:left;width:18%;color:#'. $typeColor .';">'. $show['author'] .'</div><div style="float:left;width:20%;color:#'. $typeColor .';">'. $show['authorUrl'] .'</div><div style="float:right;width:10%;color:#'. $typeColor .';text-align:center;">'. $show['type'] .'</div><br style="clear:both" /></div>';
 


### PR DESCRIPTION
I have just started experimenting with PHP language, and when I noticed that this script fails with PHP 7.1 , I thought it could be a useful learning experience trying to fix it.
My coding experience is limited to visual basic, so please check that I haven't opened Pandora's box with my changes.

Comments to changes at line number:
773 and 959:
Dealing with the fact that libraries/platform.php have been missing from joomla distributions since 3.6.3

1131:
Script does not take into account all the localhost installations with no dbPassword

1910 and 2400:
Fails in PHP 7.1
On second thought... it would probably be better to just comment out these two lines ?

1938:
Added protostar and isis to core templates.

2426:
Added later versions. Probably not 100% correct parameters.

2825:
Added the "delete script after use" notice to the finished page.

*********************
Second batch.
Added check box to show/hide core extensions.
Fixed the other check boxes so they behave as expected.
Added color to the extensions in forum output. Core is blue, 3rdP orange.

*********************
Anybody home?
Third batch.
Added Extensions enabled (1) or not (0) to the forum post output.