### PR TITLE
Update fpa-en.php

### DIFF
--- a/fpa-en.php
+++ b/fpa-en.php
@@ -134,6 +134,8 @@
             }
 
         }
+    } else {
+        $fpaEXPIRENOTICE = '';
     } // if _FPA_SELF_DESTRUCT defined
 
 


### PR DESCRIPTION
Update to avoid variable not defined error when SELF_DESTRUCT disabled.