### PR TITLE
Postgre sql user privileges

### DIFF
--- a/fpa-en.php
+++ b/fpa-en.php
@@ -22,8 +22,8 @@
      */
      define ( '_RES', 'Forum Post Assistant' );
      define ( '_RES_VERSION', '1.6.3' );
-     define ( '_RES_CODENAME', 'kahdeksan' );
-     define ( '_RES_LAST_UPDATED', '2-Sep-2021' );
+     define ( '_RES_CODENAME', 'loxodonta' );
+     define ( '_RES_LAST_UPDATED', '24-Sep-2021' );
      define ( '_RES_RELEASE', 'Stable' );              // can be Alpha, Beta, RC, Stable
      define ( '_RES_LANG', 'en-GB' );                 // Country/Language Code
      define ( '_RES_COPYRIGHT_STMT', ' Copyright &copy; 2011-'. @date("Y").  ' Russell Winter, Phil DeGruy, Bernard Toplak, Claire Mandville, Sveinung Larsen. <br>' );


### PR DESCRIPTION
First attempt at presenting sufficient database-user privileges for PostgreSQL. #69 
My approach is to check these privileges in the listed order, and present the first found.
Superuser (No problem. All privileges.)
Database Owner (Owners have all privileges to the object, so should be ok.)
Table Owner (Here we check if the user is owner of the #_extension table. Even if an admin has created the db, the tables are created by Joomla, and owned by user. Should be ok.)
The user could have sufficient privileges without these if the user inherit privileges from another user, but that rabbit hole is too deep at the moment so status 'Unknown'.
A lot of assumptions here, so it would be nice if someone familiar with PostgreSQL could have a look.

Other changes:
Discovered that insufficient privileges caused fatal errors, possibly due to PHP 8.0
Had to extend the try -> catch range in pgsql (pdo), and check for false return (=error) on the first executed query in postgresql.

Re-arranged a bit at the start of the script to make sure error reporting is turned off before anything that could cause an error is executed.
Moved the GZip routine down a bit, and inserted a new display error on/off routine. Previously the ini_set( 'display_errors' was not turned off until around line 1400.